### PR TITLE
Bug: Context, arguments missing in addEventListener/removeEventListener/dispatchEvent

### DIFF
--- a/js/tquery.core.js
+++ b/js/tquery.core.js
@@ -327,8 +327,8 @@ tQuery.MicroeventMixin	= function(destObj){
 		this.unbind(event, fct)
 		return this;	// for chained API
 	}
-	destObj.dispatchEvent		= function(event){
-		this.trigger(event)
+	destObj.dispatchEvent		= function(event /* , args... */){
+		this.trigger.apply(this, arguments)
 		return this;
 	}
 };


### PR DESCRIPTION
The methods for addEventListener/removeEventListener/dispatchEvent forward to `destObj.bind/unbind/trigger()`. When destObj is a prototype, this means events are bound to the class, not the instance.

Additionally, dispatchEvent does not pass variable arguments along to .trigger().
